### PR TITLE
RubyGemsの脆弱性対応（2.7.4 -> 2.7.6）

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM xenodatalab/base-ruby:ruby-2.5.0
+FROM xenodatalab/base-ruby:ruby-2.5.0_gems-2.7.6
 
 MAINTAINER xenodatalab <development@xenodata-lab.com>
 


### PR DESCRIPTION
https://xenodata.backlog.com/view/DATE-731

RubyGems の複数の脆弱性について
https://www.ruby-lang.org/ja/news/2018/02/17/multiple-vulnerabilities-in-rubygems/